### PR TITLE
feat: cross-server alerting and shared suspicious list over Redis (Lettuce)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If API access is not available yet, disable the AI check for now.
 
 ## Configuration files
 
-- [`config.yml`](src/main/resources/config.yml): AI, database, alerts, duplicate packet handling
+- [`config.yml`](src/main/resources/config.yml): AI, database, Redis, cross-server alerts, alerts, duplicate packet handling
 - [`monitor.yml`](src/main/resources/monitor.yml): formatting for `/sloth monitor` and `/sloth view`
 - [`punishments.yml`](src/main/resources/punishments.yml): punishment rules
 - [`messages/messages_en.yml`](src/main/resources/messages/messages_en.yml): English messages

--- a/README.ru.md
+++ b/README.ru.md
@@ -57,7 +57,7 @@ AI-проверка Sloth использует официальный Sloth API.
 
 ## Файлы конфигурации
 
-- [`config.yml`](src/main/resources/config.yml): AI, база данных, алерты и обработка дублирующихся пакетов движения
+- [`config.yml`](src/main/resources/config.yml): AI, база данных, Redis, межсерверные алёрты, алерты и обработка дублирующихся пакетов движения
 - [`monitor.yml`](src/main/resources/monitor.yml): формат `/sloth monitor` и `/sloth view`
 - [`punishments.yml`](src/main/resources/punishments.yml): правила наказаний
 - [`messages/messages_en.yml`](src/main/resources/messages/messages_en.yml): английская локализация

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,8 +70,12 @@ dependencies {
   implementation("org.mariadb.jdbc:mariadb-java-client:3.5.7")
   implementation("com.fasterxml.jackson.core:jackson-databind:2.21.2")
 
-  // Redis (cross-server alerts)
-  implementation("io.lettuce:lettuce-core:6.5.0.RELEASE")
+  // Redis (cross-server alerts).
+  // Netty must NOT be bundled or relocated: the server provides io.netty, and PacketEvents finds the
+  // player's Channel by reflecting on its io.netty type. Relocating it breaks that lookup, so Lettuce
+  // shares the server's Netty (provided at compile time below, supplied by the server at runtime).
+  implementation("io.lettuce:lettuce-core:6.5.0.RELEASE") { exclude(group = "io.netty") }
+  compileOnly("io.netty:netty-handler:4.1.113.Final")
 
   // Utilities
   implementation(kotlin("stdlib"))
@@ -94,6 +98,8 @@ dependencies {
   testCompileOnly("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
   testRuntimeOnly("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
   testRuntimeOnly("org.xerial:sqlite-jdbc:3.51.3.0")
+  // Server provides Netty at runtime; tests have no server, so give Lettuce its Netty here.
+  testRuntimeOnly("io.netty:netty-handler:4.1.113.Final")
 }
 
 java {
@@ -136,9 +142,8 @@ tasks.shadowJar {
     exclude(dependency("org.flywaydb:flyway-core"))
     exclude(dependency("org.flywaydb:flyway-mysql"))
     exclude(dependency("org.mariadb.jdbc:mariadb-java-client"))
-    // Lettuce, Netty and Reactor wire themselves up reflectively; keep them whole.
+    // Lettuce and Reactor wire themselves up reflectively; keep them whole.
     exclude(dependency("io.lettuce:lettuce-core"))
-    exclude(dependency("io.netty:.*:.*"))
     exclude(dependency("io.projectreactor:reactor-core"))
     exclude(dependency("org.reactivestreams:reactive-streams"))
   }
@@ -167,7 +172,6 @@ tasks.shadowJar {
   relocate("org.flywaydb", "space.kaelus.sloth.libs.flyway")
   relocate("tools.jackson", "space.kaelus.sloth.libs.tools.jackson")
   relocate("io.lettuce", "space.kaelus.sloth.libs.lettuce")
-  relocate("io.netty", "space.kaelus.sloth.libs.netty")
   relocate("reactor", "space.kaelus.sloth.libs.reactor")
   relocate("org.reactivestreams", "space.kaelus.sloth.libs.reactivestreams")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,8 +71,10 @@ dependencies {
   implementation("com.fasterxml.jackson.core:jackson-databind:2.21.2")
 
   // Redis (cross-server alerts).
-  // Netty must NOT be bundled or relocated: the server provides io.netty, and PacketEvents finds the
-  // player's Channel by reflecting on its io.netty type. Relocating it breaks that lookup, so Lettuce
+  // Netty must NOT be bundled or relocated: the server provides io.netty, and PacketEvents finds
+  // the
+  // player's Channel by reflecting on its io.netty type. Relocating it breaks that lookup, so
+  // Lettuce
   // shares the server's Netty (provided at compile time below, supplied by the server at runtime).
   implementation("io.lettuce:lettuce-core:6.5.0.RELEASE") { exclude(group = "io.netty") }
   compileOnly("io.netty:netty-handler:4.1.113.Final")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
   implementation("net.kyori:adventure-platform-bukkit:4.4.1")
   implementation("net.kyori:adventure-text-minimessage:4.26.1")
   implementation("net.kyori:adventure-text-serializer-plain:4.26.1")
+  implementation("net.kyori:adventure-text-serializer-gson:4.26.1")
 
   // HikariCP
   implementation("com.zaxxer:HikariCP:7.0.2")
@@ -68,6 +69,9 @@ dependencies {
   implementation("org.flywaydb:flyway-mysql:12.1.1")
   implementation("org.mariadb.jdbc:mariadb-java-client:3.5.7")
   implementation("com.fasterxml.jackson.core:jackson-databind:2.21.2")
+
+  // Redis (cross-server alerts)
+  implementation("io.lettuce:lettuce-core:6.5.0.RELEASE")
 
   // Utilities
   implementation(kotlin("stdlib"))
@@ -132,6 +136,11 @@ tasks.shadowJar {
     exclude(dependency("org.flywaydb:flyway-core"))
     exclude(dependency("org.flywaydb:flyway-mysql"))
     exclude(dependency("org.mariadb.jdbc:mariadb-java-client"))
+    // Lettuce, Netty and Reactor wire themselves up reflectively; keep them whole.
+    exclude(dependency("io.lettuce:lettuce-core"))
+    exclude(dependency("io.netty:.*:.*"))
+    exclude(dependency("io.projectreactor:reactor-core"))
+    exclude(dependency("org.reactivestreams:reactive-streams"))
   }
 
   mergeServiceFiles()
@@ -157,6 +166,10 @@ tasks.shadowJar {
   relocate("org.koin", "space.kaelus.sloth.libs.koin")
   relocate("org.flywaydb", "space.kaelus.sloth.libs.flyway")
   relocate("tools.jackson", "space.kaelus.sloth.libs.tools.jackson")
+  relocate("io.lettuce", "space.kaelus.sloth.libs.lettuce")
+  relocate("io.netty", "space.kaelus.sloth.libs.netty")
+  relocate("reactor", "space.kaelus.sloth.libs.reactor")
+  relocate("org.reactivestreams", "space.kaelus.sloth.libs.reactivestreams")
 }
 
 tasks.register<PrintFilePathTask>("printShadowJarPath") {

--- a/src/main/kotlin/space/kaelus/sloth/SlothCore.kt
+++ b/src/main/kotlin/space/kaelus/sloth/SlothCore.kt
@@ -33,6 +33,7 @@ import space.kaelus.sloth.monitor.MonitorViewService
 import space.kaelus.sloth.packet.PacketListener
 import space.kaelus.sloth.player.PlayerDataManager
 import space.kaelus.sloth.redis.CrossServerAlertService
+import space.kaelus.sloth.redis.CrossServerSuspiciousService
 import space.kaelus.sloth.redis.RedisManager
 import space.kaelus.sloth.server.AIServerProvider
 import space.kaelus.sloth.utils.MessageUtil
@@ -50,6 +51,7 @@ constructor(
   private val databaseManager: DatabaseManager,
   private val redisManager: RedisManager,
   private val crossServerAlertService: CrossServerAlertService,
+  private val crossServerSuspiciousService: CrossServerSuspiciousService,
   private val debugManager: DebugManager,
   private val packetListener: PacketListener,
   private val monitorViewService: MonitorViewService,
@@ -72,6 +74,7 @@ constructor(
       ServicePriority.Normal,
     )
     crossServerAlertService.start()
+    crossServerSuspiciousService.start()
   }
 
   fun disable() {
@@ -79,6 +82,7 @@ constructor(
     runCatching { playerDataManager.saveAllBuffersSync() }
     runCatching { aiServerProvider.shutdownTransport() }
     runCatching { crossServerAlertService.shutdown() }
+    runCatching { crossServerSuspiciousService.shutdown() }
     runCatching { redisManager.shutdown() }
     adventure.close()
     coroutines.close()
@@ -93,7 +97,12 @@ constructor(
     aiServerProvider.reload()
     playerDataManager.reloadAllPlayers()
     monitorViewService.reload()
-    crossServerAlertService.reload()
+    // Restart Redis once, then re-init both consumers so the alert subscription survives reload.
+    crossServerAlertService.shutdown()
+    crossServerSuspiciousService.shutdown()
+    redisManager.shutdown()
+    crossServerAlertService.start()
+    crossServerSuspiciousService.start()
   }
 
   private fun initializePacketRuntime() {

--- a/src/main/kotlin/space/kaelus/sloth/SlothCore.kt
+++ b/src/main/kotlin/space/kaelus/sloth/SlothCore.kt
@@ -32,6 +32,8 @@ import space.kaelus.sloth.event.DamageEvent
 import space.kaelus.sloth.monitor.MonitorViewService
 import space.kaelus.sloth.packet.PacketListener
 import space.kaelus.sloth.player.PlayerDataManager
+import space.kaelus.sloth.redis.CrossServerAlertService
+import space.kaelus.sloth.redis.RedisManager
 import space.kaelus.sloth.server.AIServerProvider
 import space.kaelus.sloth.utils.MessageUtil
 
@@ -46,6 +48,8 @@ constructor(
   private val commandManager: CommandManager,
   private val alertManager: AlertManager,
   private val databaseManager: DatabaseManager,
+  private val redisManager: RedisManager,
+  private val crossServerAlertService: CrossServerAlertService,
   private val debugManager: DebugManager,
   private val packetListener: PacketListener,
   private val monitorViewService: MonitorViewService,
@@ -67,12 +71,15 @@ constructor(
       plugin,
       ServicePriority.Normal,
     )
+    crossServerAlertService.start()
   }
 
   fun disable() {
     plugin.server.servicesManager.unregister(SlothApi::class.java, slothApi)
     runCatching { playerDataManager.saveAllBuffersSync() }
     runCatching { aiServerProvider.shutdownTransport() }
+    runCatching { crossServerAlertService.shutdown() }
+    runCatching { redisManager.shutdown() }
     adventure.close()
     coroutines.close()
     databaseManager.shutdown()
@@ -86,6 +93,7 @@ constructor(
     aiServerProvider.reload()
     playerDataManager.reloadAllPlayers()
     monitorViewService.reload()
+    crossServerAlertService.reload()
   }
 
   private fun initializePacketRuntime() {

--- a/src/main/kotlin/space/kaelus/sloth/alert/AlertManager.kt
+++ b/src/main/kotlin/space/kaelus/sloth/alert/AlertManager.kt
@@ -48,6 +48,12 @@ class AlertManager(
 
   private var logToConsole = true
 
+  /**
+   * Bridge that mirrors alerts to other servers, or `null` for local-only behaviour. Set by the
+   * Redis bridge on start-up and cleared on shutdown.
+   */
+  @Volatile var crossServerPublisher: CrossServerPublisher? = null
+
   var alertFormat: String = ""
     private set
 
@@ -84,7 +90,18 @@ class AlertManager(
     }
   }
 
+  /** Delivers an alert to local subscribers and the console, then mirrors it to other servers. */
   fun send(component: Component, type: AlertType) {
+    deliver(component, type)
+    crossServerPublisher?.publish(type, component)
+  }
+
+  /**
+   * Delivers an alert to local subscribers and the console only. Used both by [send] and by the
+   * cross-server bridge for alerts received from other servers, which must not be mirrored back
+   * out.
+   */
+  fun deliver(component: Component, type: AlertType) {
     val playersSet = playersWithAlerts.getValue(type)
     val permission = type.permission
 

--- a/src/main/kotlin/space/kaelus/sloth/alert/CrossServerPublisher.kt
+++ b/src/main/kotlin/space/kaelus/sloth/alert/CrossServerPublisher.kt
@@ -1,0 +1,30 @@
+/*
+ * This file is part of SlothAC - https://github.com/KaelusMC/SlothAC
+ * Copyright (C) 2026 KaelusMC
+ *
+ * SlothAC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SlothAC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package space.kaelus.sloth.alert
+
+import net.kyori.adventure.text.Component
+
+/**
+ * Mirrors a locally-raised alert to other servers.
+ *
+ * Implemented by the Redis bridge and registered on [AlertManager] at runtime so the alert package
+ * keeps no dependency on the transport.
+ */
+fun interface CrossServerPublisher {
+  fun publish(type: AlertType, component: Component)
+}

--- a/src/main/kotlin/space/kaelus/sloth/command/commands/admin/SuspiciousCommand.kt
+++ b/src/main/kotlin/space/kaelus/sloth/command/commands/admin/SuspiciousCommand.kt
@@ -33,7 +33,7 @@ import space.kaelus.sloth.command.SlothCommand
 import space.kaelus.sloth.command.requirements.PlayerSenderRequirement
 import space.kaelus.sloth.database.DatabaseManager
 import space.kaelus.sloth.player.PlayerDataManager
-import space.kaelus.sloth.player.SlothPlayer
+import space.kaelus.sloth.redis.CrossServerSuspiciousService
 import space.kaelus.sloth.scheduler.SchedulerService
 import space.kaelus.sloth.sender.Sender
 import space.kaelus.sloth.utils.Message
@@ -44,8 +44,14 @@ class SuspiciousCommand(
   private val alertManager: AlertManager,
   private val databaseManager: DatabaseManager,
   private val scheduler: SchedulerService,
+  private val crossServerSuspiciousService: CrossServerSuspiciousService,
 ) : SlothCommand {
-  private data class SuspiciousEntry(val player: SlothPlayer, val check: AiCheck)
+  private data class DisplayEntry(
+    val server: String,
+    val name: String,
+    val buffer: Double,
+    val ping: Int,
+  )
 
   private data class FlaggedPlayerEntry(val playerName: String, val flags: Int)
 
@@ -91,91 +97,111 @@ class SuspiciousCommand(
 
   private fun executeList(context: CommandContext<Sender>) {
     val sender = context.sender()
-    val bufferFilter = 0.0
+    val local = collectLocalSuspicious()
 
-    val suspiciousPlayers = ArrayList<SuspiciousEntry>()
-    for (sp in playerDataManager.getPlayers()) {
-      val check = sp.checkManager.getCheck(AiCheck::class.java) ?: continue
-      if (check.buffer > bufferFilter) {
-        suspiciousPlayers.add(SuspiciousEntry(sp, check))
-      }
-    }
-
-    suspiciousPlayers.sortByDescending { it.check.buffer }
-
-    if (suspiciousPlayers.isEmpty()) {
-      sender.sendMessage(MessageUtil.getMessage(Message.SUSPICIOUS_LIST_EMPTY))
+    if (!crossServerSuspiciousService.isActive) {
+      renderList(sender, local, tagged = false)
       return
     }
 
-    sender.sendMessage(
-      MessageUtil.getMessage(
-        Message.SUSPICIOUS_LIST_HEADER,
-        "count",
-        suspiciousPlayers.size.toString(),
-      )
-    )
-
-    for (item in suspiciousPlayers) {
-      val buffer = item.check.buffer
-      val playerName = item.player.player.name
-
-      val message: Component =
-        MessageUtil.getMessage(
-            Message.SUSPICIOUS_LIST_ENTRY,
-            "player",
-            playerName,
-            "buffer",
-            String.format(Locale.US, "%.1f", buffer),
-            "ping",
-            item.player.player.ping.toString(),
-          )
-          .hoverEvent(
-            HoverEvent.showText(MessageUtil.getMessage(Message.SUSPICIOUS_LIST_ENTRY_HOVER))
-          )
-          .clickEvent(ClickEvent.runCommand("/sloth profile $playerName"))
-
-      sender.sendMessage(message)
+    scheduler.runAsync {
+      val merged = (local + fetchRemoteEntries()).sortedByDescending { it.buffer }
+      scheduler.runSync { renderList(sender, merged, tagged = true) }
     }
   }
 
   private fun executeTop(context: CommandContext<Sender>) {
     val sender = context.sender()
+    val local = collectLocalSuspicious()
 
-    var topPlayer: SlothPlayer? = null
-    var topBuffer = 0.0
-
-    for (sp in playerDataManager.getPlayers()) {
-      val check = sp.checkManager.getCheck(AiCheck::class.java) ?: continue
-      val buffer = check.buffer
-      if (buffer > topBuffer) {
-        topBuffer = buffer
-        topPlayer = sp
-      }
+    if (!crossServerSuspiciousService.isActive) {
+      renderTop(sender, local.maxByOrNull { it.buffer }, tagged = false)
+      return
     }
 
-    if (topPlayer == null || topBuffer == 0.0) {
+    scheduler.runAsync {
+      val top = (local + fetchRemoteEntries()).maxByOrNull { it.buffer }
+      scheduler.runSync { renderTop(sender, top, tagged = true) }
+    }
+  }
+
+  private fun collectLocalSuspicious(): List<DisplayEntry> {
+    val server = crossServerSuspiciousService.serverName
+    val entries = ArrayList<DisplayEntry>()
+    for (sp in playerDataManager.getPlayers()) {
+      val check = sp.checkManager.getCheck(AiCheck::class.java) ?: continue
+      if (check.buffer > 0.0) {
+        entries.add(DisplayEntry(server, sp.player.name, check.buffer, sp.player.ping))
+      }
+    }
+    return entries
+  }
+
+  private fun fetchRemoteEntries(): List<DisplayEntry> =
+    crossServerSuspiciousService.fetchRemote().map {
+      DisplayEntry(it.server, it.name, it.buffer, it.ping)
+    }
+
+  private fun renderList(sender: Sender, entries: List<DisplayEntry>, tagged: Boolean) {
+    if (entries.isEmpty()) {
+      sender.sendMessage(MessageUtil.getMessage(Message.SUSPICIOUS_LIST_EMPTY))
+      return
+    }
+
+    sender.sendMessage(
+      MessageUtil.getMessage(Message.SUSPICIOUS_LIST_HEADER, "count", entries.size.toString())
+    )
+
+    for (entry in entries) {
+      val line =
+        MessageUtil.getMessage(
+            Message.SUSPICIOUS_LIST_ENTRY,
+            "player",
+            entry.name,
+            "buffer",
+            String.format(Locale.US, "%.1f", entry.buffer),
+            "ping",
+            entry.ping.toString(),
+          )
+          .hoverEvent(
+            HoverEvent.showText(MessageUtil.getMessage(Message.SUSPICIOUS_LIST_ENTRY_HOVER))
+          )
+          .clickEvent(ClickEvent.runCommand("/sloth profile ${entry.name}"))
+
+      sender.sendMessage(withServerTag(entry.server, line, tagged))
+    }
+  }
+
+  private fun renderTop(sender: Sender, top: DisplayEntry?, tagged: Boolean) {
+    if (top == null) {
       sender.sendMessage(MessageUtil.getMessage(Message.SUSPICIOUS_TOP_NONE))
       return
     }
 
-    val playerName = topPlayer.player.name
-
-    val message: Component =
+    val line =
       MessageUtil.getMessage(
           Message.SUSPICIOUS_TOP_PLAYER,
           "player",
-          playerName,
+          top.name,
           "buffer",
-          String.format(Locale.US, "%.1f", topBuffer),
+          String.format(Locale.US, "%.1f", top.buffer),
         )
         .hoverEvent(
           HoverEvent.showText(MessageUtil.getMessage(Message.SUSPICIOUS_TOP_PLAYER_HOVER))
         )
-        .clickEvent(ClickEvent.runCommand("/sloth monitor $playerName"))
+        .clickEvent(ClickEvent.runCommand("/sloth monitor ${top.name}"))
 
-    sender.sendMessage(message)
+    sender.sendMessage(withServerTag(top.server, line, tagged))
   }
+
+  private fun withServerTag(server: String, line: Component, tagged: Boolean): Component =
+    if (tagged) {
+      MessageUtil.getMessage(Message.CROSS_SERVER_SERVER_TAG, "server", server)
+        .append(Component.space())
+        .append(line)
+    } else {
+      line
+    }
 
   private fun executeFlagged(context: CommandContext<Sender>) {
     val sender = context.sender()

--- a/src/main/kotlin/space/kaelus/sloth/command/commands/admin/SuspiciousCommand.kt
+++ b/src/main/kotlin/space/kaelus/sloth/command/commands/admin/SuspiciousCommand.kt
@@ -39,6 +39,27 @@ import space.kaelus.sloth.sender.Sender
 import space.kaelus.sloth.utils.Message
 import space.kaelus.sloth.utils.MessageUtil
 
+/** A suspicious player as shown in the list, from this server (local) or another (remote). */
+internal data class DisplayEntry(
+  val server: String,
+  val uuid: String,
+  val name: String,
+  val buffer: Double,
+  val ping: Int,
+  val updatedAt: Long,
+)
+
+/**
+ * Collapses entries for the same player to one row, keeping the freshest. Local entries use
+ * [Long.MAX_VALUE] for [DisplayEntry.updatedAt], so a player on the viewer's own server always wins
+ * over a stale entry left behind on a server they just moved away from.
+ */
+internal fun dedupeByPlayer(entries: List<DisplayEntry>): List<DisplayEntry> =
+  entries
+    .groupBy { it.uuid }
+    .values
+    .map { group -> group.reduce { a, b -> if (b.updatedAt >= a.updatedAt) b else a } }
+
 class SuspiciousCommand(
   private val playerDataManager: PlayerDataManager,
   private val alertManager: AlertManager,
@@ -46,13 +67,6 @@ class SuspiciousCommand(
   private val scheduler: SchedulerService,
   private val crossServerSuspiciousService: CrossServerSuspiciousService,
 ) : SlothCommand {
-  private data class DisplayEntry(
-    val server: String,
-    val name: String,
-    val buffer: Double,
-    val ping: Int,
-  )
-
   private data class FlaggedPlayerEntry(val playerName: String, val flags: Int)
 
   override fun register(manager: CommandManager<Sender>) {
@@ -105,7 +119,7 @@ class SuspiciousCommand(
     }
 
     scheduler.runAsync {
-      val merged = (local + fetchRemoteEntries()).sortedByDescending { it.buffer }
+      val merged = dedupeByPlayer(local + fetchRemoteEntries()).sortedByDescending { it.buffer }
       scheduler.runSync { renderList(sender, merged, tagged = true) }
     }
   }
@@ -120,7 +134,7 @@ class SuspiciousCommand(
     }
 
     scheduler.runAsync {
-      val top = (local + fetchRemoteEntries()).maxByOrNull { it.buffer }
+      val top = dedupeByPlayer(local + fetchRemoteEntries()).maxByOrNull { it.buffer }
       scheduler.runSync { renderTop(sender, top, tagged = true) }
     }
   }
@@ -131,7 +145,17 @@ class SuspiciousCommand(
     for (sp in playerDataManager.getPlayers()) {
       val check = sp.checkManager.getCheck(AiCheck::class.java) ?: continue
       if (check.buffer > 0.0) {
-        entries.add(DisplayEntry(server, sp.player.name, check.buffer, sp.player.ping))
+        // Local players are authoritative: MAX_VALUE makes them win de-duplication.
+        entries.add(
+          DisplayEntry(
+            server,
+            sp.uuid.toString(),
+            sp.player.name,
+            check.buffer,
+            sp.player.ping,
+            Long.MAX_VALUE,
+          )
+        )
       }
     }
     return entries
@@ -139,7 +163,7 @@ class SuspiciousCommand(
 
   private fun fetchRemoteEntries(): List<DisplayEntry> =
     crossServerSuspiciousService.fetchRemote().map {
-      DisplayEntry(it.server, it.name, it.buffer, it.ping)
+      DisplayEntry(it.server, it.uuid, it.name, it.buffer, it.ping, it.updatedAt)
     }
 
   private fun renderList(sender: Sender, entries: List<DisplayEntry>, tagged: Boolean) {

--- a/src/main/kotlin/space/kaelus/sloth/config/ConfigMigrations.kt
+++ b/src/main/kotlin/space/kaelus/sloth/config/ConfigMigrations.kt
@@ -20,7 +20,7 @@ package space.kaelus.sloth.config
 import java.io.File
 
 internal object ConfigMigrations {
-  const val LATEST_VERSION = 1
+  const val LATEST_VERSION = 2
 
   private val VERSION_RE = Regex("""^\s*config-version:\s*(\d+)""", RegexOption.MULTILINE)
 

--- a/src/main/kotlin/space/kaelus/sloth/config/ConfigMigrations.kt
+++ b/src/main/kotlin/space/kaelus/sloth/config/ConfigMigrations.kt
@@ -20,7 +20,7 @@ package space.kaelus.sloth.config
 import java.io.File
 
 internal object ConfigMigrations {
-  const val LATEST_VERSION = 2
+  const val LATEST_VERSION = 3
 
   private val VERSION_RE = Regex("""^\s*config-version:\s*(\d+)""", RegexOption.MULTILINE)
 

--- a/src/main/kotlin/space/kaelus/sloth/di/SlothKoinModules.kt
+++ b/src/main/kotlin/space/kaelus/sloth/di/SlothKoinModules.kt
@@ -93,6 +93,8 @@ import space.kaelus.sloth.platform.scheduler.PlatformSchedulerFactory
 import space.kaelus.sloth.player.ExemptManager
 import space.kaelus.sloth.player.PlayerDataManager
 import space.kaelus.sloth.punishment.PunishmentManager
+import space.kaelus.sloth.redis.CrossServerAlertService
+import space.kaelus.sloth.redis.RedisManager
 import space.kaelus.sloth.region.RegionProvider
 import space.kaelus.sloth.scheduler.SchedulerService
 import space.kaelus.sloth.sender.Sender
@@ -119,6 +121,8 @@ private fun coreModule(plugin: SlothAC) = module {
   singleOf(::DebugManager)
   singleOf(::AIServerProvider)
   singleOf(::AlertManager)
+  singleOf(::RedisManager)
+  singleOf(::CrossServerAlertService)
   singleOf(::MonitorSettingsService)
   singleOf(::MonitorViewService)
   singleOf(::ExemptManager)

--- a/src/main/kotlin/space/kaelus/sloth/di/SlothKoinModules.kt
+++ b/src/main/kotlin/space/kaelus/sloth/di/SlothKoinModules.kt
@@ -94,6 +94,7 @@ import space.kaelus.sloth.player.ExemptManager
 import space.kaelus.sloth.player.PlayerDataManager
 import space.kaelus.sloth.punishment.PunishmentManager
 import space.kaelus.sloth.redis.CrossServerAlertService
+import space.kaelus.sloth.redis.CrossServerSuspiciousService
 import space.kaelus.sloth.redis.RedisManager
 import space.kaelus.sloth.region.RegionProvider
 import space.kaelus.sloth.scheduler.SchedulerService
@@ -123,6 +124,7 @@ private fun coreModule(plugin: SlothAC) = module {
   singleOf(::AlertManager)
   singleOf(::RedisManager)
   singleOf(::CrossServerAlertService)
+  singleOf(::CrossServerSuspiciousService)
   singleOf(::MonitorSettingsService)
   singleOf(::MonitorViewService)
   singleOf(::ExemptManager)

--- a/src/main/kotlin/space/kaelus/sloth/redis/CrossServerAlert.kt
+++ b/src/main/kotlin/space/kaelus/sloth/redis/CrossServerAlert.kt
@@ -1,0 +1,38 @@
+/*
+ * This file is part of SlothAC - https://github.com/KaelusMC/SlothAC
+ * Copyright (C) 2026 KaelusMC
+ *
+ * SlothAC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SlothAC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package space.kaelus.sloth.redis
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * Wire payload for a mirrored alert, serialized as JSON onto the Redis channel.
+ *
+ * @property origin per-process id of the publishing server, used to ignore our own messages
+ * @property server display name of the origin server, shown as the `[server]` tag
+ * @property type the alert type name (`REGULAR` or `SUSPICIOUS`)
+ * @property component the rendered alert message, serialized with `GsonComponentSerializer`
+ */
+data class CrossServerAlert
+@JsonCreator
+constructor(
+  @param:JsonProperty("origin") val origin: String,
+  @param:JsonProperty("server") val server: String,
+  @param:JsonProperty("type") val type: String,
+  @param:JsonProperty("component") val component: String,
+)

--- a/src/main/kotlin/space/kaelus/sloth/redis/CrossServerAlertService.kt
+++ b/src/main/kotlin/space/kaelus/sloth/redis/CrossServerAlertService.kt
@@ -1,0 +1,145 @@
+/*
+ * This file is part of SlothAC - https://github.com/KaelusMC/SlothAC
+ * Copyright (C) 2026 KaelusMC
+ *
+ * SlothAC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SlothAC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package space.kaelus.sloth.redis
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.util.EnumSet
+import java.util.UUID
+import java.util.logging.Level
+import java.util.logging.Logger
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
+import space.kaelus.sloth.alert.AlertManager
+import space.kaelus.sloth.alert.AlertType
+import space.kaelus.sloth.alert.CrossServerPublisher
+import space.kaelus.sloth.config.ConfigManager
+import space.kaelus.sloth.utils.Message
+import space.kaelus.sloth.utils.MessageUtil
+
+/**
+ * Bridges the local [AlertManager] with other servers over Redis pub/sub.
+ *
+ * When enabled, it publishes locally-raised [AlertType.REGULAR] and [AlertType.SUSPICIOUS] alerts
+ * to the shared channel and, in the other direction, delivers alerts received from other servers to
+ * local staff with a `[server]` origin tag. Alerts received over Redis are delivered through
+ * [AlertManager.deliver] so they are never mirrored back out, and messages this server published
+ * are dropped on arrival via the per-process [origin] id.
+ */
+class CrossServerAlertService(
+  private val configManager: ConfigManager,
+  private val redisManager: RedisManager,
+  private val alertManager: AlertManager,
+  private val logger: Logger,
+) {
+  private val origin: String = UUID.randomUUID().toString()
+  private val mapper = ObjectMapper()
+  private val componentSerializer = GsonComponentSerializer.gson()
+  private val mirroredTypes: MutableSet<AlertType> = EnumSet.noneOf(AlertType::class.java)
+
+  @Volatile private var enabled = false
+  private var serverName = DEFAULT_SERVER_NAME
+  private var channel = DEFAULT_CHANNEL
+
+  fun start() {
+    val config = configManager.config
+    if (!config.getBoolean("cross-server.enabled", false)) return
+
+    serverName = config.getString("cross-server.server-name", DEFAULT_SERVER_NAME)
+    channel = config.getString("cross-server.channel", DEFAULT_CHANNEL)
+    mirroredTypes.clear()
+    if (config.getBoolean("cross-server.alerts.regular", true)) mirroredTypes.add(AlertType.REGULAR)
+    if (config.getBoolean("cross-server.alerts.suspicious", true)) {
+      mirroredTypes.add(AlertType.SUSPICIOUS)
+    }
+
+    redisManager.start()
+    if (!redisManager.isAvailable) {
+      logger.warning(
+        "[CrossServer] cross-server.enabled is true but Redis is unavailable; alerts stay local."
+      )
+      return
+    }
+
+    redisManager.subscribe(channel, ::onMessage)
+    alertManager.crossServerPublisher = CrossServerPublisher { type, component ->
+      publish(type, component)
+    }
+    enabled = true
+    logger.info(
+      "[CrossServer] Mirroring ${mirroredTypes.joinToString(", ")} alerts as " +
+        "\"$serverName\" on channel \"$channel\"."
+    )
+  }
+
+  /**
+   * Mirrors a locally-raised alert to other servers. Wired into [AlertManager] as the publisher.
+   */
+  fun publish(type: AlertType, component: Component) {
+    if (!enabled || type !in mirroredTypes) return
+    val payload =
+      runCatching {
+          val alert =
+            CrossServerAlert(
+              origin,
+              serverName,
+              type.name,
+              componentSerializer.serialize(component),
+            )
+          mapper.writeValueAsString(alert)
+        }
+        .getOrElse { error ->
+          logger.log(Level.FINE, "[CrossServer] Failed to serialize alert.", error)
+          return
+        }
+    redisManager.publishAsync(channel, payload)
+  }
+
+  private fun onMessage(raw: String) {
+    runCatching { handleMessage(raw) }
+      .onFailure { error ->
+        logger.log(Level.FINE, "[CrossServer] Failed to handle incoming alert.", error)
+      }
+  }
+
+  @Suppress("ReturnCount")
+  private fun handleMessage(raw: String) {
+    val alert = mapper.readValue(raw, CrossServerAlert::class.java)
+    if (alert.origin == origin) return // our own alert, already shown locally
+    val type = runCatching { AlertType.valueOf(alert.type) }.getOrNull() ?: return
+    if (type !in mirroredTypes) return
+    val body = componentSerializer.deserialize(alert.component)
+    val prefix = MessageUtil.getMessage(Message.CROSS_SERVER_ALERT_PREFIX, "server", alert.server)
+    alertManager.deliver(prefix.append(Component.space()).append(body), type)
+  }
+
+  fun reload() {
+    shutdown()
+    redisManager.shutdown()
+    start()
+  }
+
+  fun shutdown() {
+    enabled = false
+    alertManager.crossServerPublisher = null
+  }
+
+  private companion object {
+    const val DEFAULT_SERVER_NAME = "server-1"
+    const val DEFAULT_CHANNEL = "slothac:alerts"
+  }
+}

--- a/src/main/kotlin/space/kaelus/sloth/redis/CrossServerAlertService.kt
+++ b/src/main/kotlin/space/kaelus/sloth/redis/CrossServerAlertService.kt
@@ -127,12 +127,6 @@ class CrossServerAlertService(
     alertManager.deliver(prefix.append(Component.space()).append(body), type)
   }
 
-  fun reload() {
-    shutdown()
-    redisManager.shutdown()
-    start()
-  }
-
   fun shutdown() {
     enabled = false
     alertManager.crossServerPublisher = null

--- a/src/main/kotlin/space/kaelus/sloth/redis/CrossServerSuspiciousService.kt
+++ b/src/main/kotlin/space/kaelus/sloth/redis/CrossServerSuspiciousService.kt
@@ -32,10 +32,10 @@ import space.kaelus.sloth.scheduler.SchedulerService
  * a network-wide view.
  *
  * While enabled, a repeating task republishes this server's suspicious players as per-player keys
- * with a TTL (so entries vanish when a player calms down, leaves, or the server stops). Nothing is
- * written to Redis unless `cross-server.enabled` and `cross-server.suspicious-sync.enabled` are
- * both on. [fetchRemote] reads the other servers' entries for the command to merge with its local
- * view.
+ * with a TTL (so entries vanish when a player calms down, leaves, or the server stops). It runs
+ * under the same switch as suspicious alert mirroring: nothing is written to Redis unless
+ * `cross-server.enabled` and `cross-server.alerts.suspicious` are both on. [fetchRemote] reads the
+ * other servers' entries for the command to merge with its local view.
  */
 class CrossServerSuspiciousService(
   private val configManager: ConfigManager,
@@ -59,9 +59,10 @@ class CrossServerSuspiciousService(
 
   fun start() {
     val config = configManager.config
+    // Shares the live list under the same switch as suspicious alert mirroring.
     if (
       !config.getBoolean("cross-server.enabled", false) ||
-        !config.getBoolean("cross-server.suspicious-sync.enabled", true)
+        !config.getBoolean("cross-server.alerts.suspicious", true)
     ) {
       return
     }

--- a/src/main/kotlin/space/kaelus/sloth/redis/CrossServerSuspiciousService.kt
+++ b/src/main/kotlin/space/kaelus/sloth/redis/CrossServerSuspiciousService.kt
@@ -1,0 +1,154 @@
+/*
+ * This file is part of SlothAC - https://github.com/KaelusMC/SlothAC
+ * Copyright (C) 2026 KaelusMC
+ *
+ * SlothAC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SlothAC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package space.kaelus.sloth.redis
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.util.logging.Level
+import java.util.logging.Logger
+import space.kaelus.sloth.checks.impl.ai.AiCheck
+import space.kaelus.sloth.config.ConfigManager
+import space.kaelus.sloth.platform.scheduler.TaskHandle
+import space.kaelus.sloth.player.PlayerDataManager
+import space.kaelus.sloth.player.SlothPlayer
+import space.kaelus.sloth.scheduler.SchedulerService
+
+/**
+ * Shares each server's live suspicious players over Redis so `/sloth suspicious list|top` can show
+ * a network-wide view.
+ *
+ * While enabled, a repeating task republishes this server's suspicious players as per-player keys
+ * with a TTL (so entries vanish when a player calms down, leaves, or the server stops). Nothing is
+ * written to Redis unless `cross-server.enabled` and `cross-server.suspicious-sync.enabled` are
+ * both on. [fetchRemote] reads the other servers' entries for the command to merge with its local
+ * view.
+ */
+class CrossServerSuspiciousService(
+  private val configManager: ConfigManager,
+  private val redisManager: RedisManager,
+  private val playerDataManager: PlayerDataManager,
+  private val scheduler: SchedulerService,
+  private val logger: Logger,
+) {
+  private val mapper = ObjectMapper()
+
+  @Volatile private var enabled = false
+  @Volatile private var refreshTask: TaskHandle? = null
+  var serverName: String = DEFAULT_SERVER_NAME
+    private set
+
+  private var keyPrefix = "$DEFAULT_CHANNEL:suspect"
+  private var ttlSeconds = DEFAULT_TTL_SECONDS
+
+  val isActive: Boolean
+    get() = enabled
+
+  fun start() {
+    val config = configManager.config
+    if (
+      !config.getBoolean("cross-server.enabled", false) ||
+        !config.getBoolean("cross-server.suspicious-sync.enabled", true)
+    ) {
+      return
+    }
+
+    serverName = config.getString("cross-server.server-name", DEFAULT_SERVER_NAME)
+    val channel = config.getString("cross-server.channel", DEFAULT_CHANNEL)
+    keyPrefix = "$channel:suspect"
+    ttlSeconds = config.getLong("cross-server.suspicious-sync.ttl-seconds", DEFAULT_TTL_SECONDS)
+    val refreshSeconds =
+      config
+        .getLong("cross-server.suspicious-sync.refresh-seconds", DEFAULT_REFRESH_SECONDS)
+        .coerceIn(1L, ttlSeconds.coerceAtLeast(1L))
+    ttlSeconds = ttlSeconds.coerceAtLeast(refreshSeconds + 1L)
+
+    redisManager.start()
+    if (!redisManager.isAvailable) {
+      logger.warning(
+        "[CrossServer] suspicious-sync is enabled but Redis is unavailable; the list stays local."
+      )
+      return
+    }
+
+    enabled = true
+    val periodTicks = refreshSeconds * TICKS_PER_SECOND
+    refreshTask = scheduler.runTimer(::publishLocalSuspicious, periodTicks, periodTicks)
+    logger.info(
+      "[CrossServer] Sharing suspicious players as \"$serverName\" " +
+        "(refresh ${refreshSeconds}s, ttl ${ttlSeconds}s)."
+    )
+  }
+
+  /** Republishes this server's suspicious online players to Redis. Runs on the main thread. */
+  private fun publishLocalSuspicious() {
+    if (!enabled) return
+    playerDataManager.getPlayers().forEach(::publishPlayer)
+  }
+
+  private fun publishPlayer(slothPlayer: SlothPlayer) {
+    val check = slothPlayer.checkManager.getCheck(AiCheck::class.java)
+    if (check == null || check.buffer <= 0.0) return
+    val player = slothPlayer.player
+    val payload =
+      runCatching {
+          mapper.writeValueAsString(
+            SuspiciousSnapshot(
+              server = serverName,
+              uuid = slothPlayer.uuid.toString(),
+              name = player.name,
+              buffer = check.buffer,
+              ping = player.ping,
+            )
+          )
+        }
+        .getOrNull() ?: return
+    redisManager.setWithTtl("$keyPrefix:$serverName:${slothPlayer.uuid}", payload, ttlSeconds)
+  }
+
+  /**
+   * Returns suspicious players reported by other servers. Blocking (reads Redis) — call off the
+   * main thread. Entries from this server are excluded so the caller can merge in its own live
+   * view.
+   */
+  fun fetchRemote(): List<SuspiciousSnapshot> {
+    if (!enabled) return emptyList()
+    return redisManager
+      .scanValues("$keyPrefix:*")
+      .mapNotNull { raw ->
+        runCatching { mapper.readValue(raw, SuspiciousSnapshot::class.java) }
+          .onFailure { error ->
+            logger.log(Level.FINE, "[CrossServer] Bad suspect payload.", error)
+          }
+          .getOrNull()
+      }
+      .filter { it.server != serverName }
+  }
+
+  fun shutdown() {
+    enabled = false
+    refreshTask?.cancel()
+    refreshTask = null
+  }
+
+  private companion object {
+    const val DEFAULT_SERVER_NAME = "server-1"
+    const val DEFAULT_CHANNEL = "slothac:alerts"
+    const val DEFAULT_TTL_SECONDS = 30L
+    const val DEFAULT_REFRESH_SECONDS = 10L
+    const val TICKS_PER_SECOND = 20L
+  }
+}

--- a/src/main/kotlin/space/kaelus/sloth/redis/CrossServerSuspiciousService.kt
+++ b/src/main/kotlin/space/kaelus/sloth/redis/CrossServerSuspiciousService.kt
@@ -113,6 +113,7 @@ class CrossServerSuspiciousService(
               name = player.name,
               buffer = check.buffer,
               ping = player.ping,
+              updatedAt = System.currentTimeMillis(),
             )
           )
         }

--- a/src/main/kotlin/space/kaelus/sloth/redis/RedisManager.kt
+++ b/src/main/kotlin/space/kaelus/sloth/redis/RedisManager.kt
@@ -1,0 +1,141 @@
+/*
+ * This file is part of SlothAC - https://github.com/KaelusMC/SlothAC
+ * Copyright (C) 2026 KaelusMC
+ *
+ * SlothAC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SlothAC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package space.kaelus.sloth.redis
+
+import io.lettuce.core.ClientOptions
+import io.lettuce.core.RedisClient
+import io.lettuce.core.RedisURI
+import io.lettuce.core.SocketOptions
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.pubsub.RedisPubSubAdapter
+import io.lettuce.core.pubsub.StatefulRedisPubSubConnection
+import java.time.Duration
+import java.util.logging.Level
+import java.util.logging.Logger
+import space.kaelus.sloth.config.ConfigManager
+
+/**
+ * Owns the Lettuce Redis connection used for cross-server features.
+ *
+ * Mirrors [space.kaelus.sloth.database.DatabaseManager]'s resilient pattern: when `redis.enabled`
+ * is off, or the connection cannot be established, the manager logs a warning and stays disabled
+ * ([isAvailable] = `false`) instead of failing plugin start-up. Publishing is then a no-op.
+ */
+class RedisManager(private val configManager: ConfigManager, private val logger: Logger) {
+  @Volatile private var client: RedisClient? = null
+  @Volatile private var connection: StatefulRedisConnection<String, String>? = null
+  @Volatile private var pubSubConnection: StatefulRedisPubSubConnection<String, String>? = null
+
+  @Volatile
+  var isAvailable: Boolean = false
+    private set
+
+  fun start() {
+    if (isAvailable) return
+    val config = configManager.config
+    if (!config.getBoolean("redis.enabled", false)) return
+
+    val host = config.getString("redis.host", DEFAULT_HOST)
+    val port = config.getInt("redis.port", DEFAULT_PORT)
+    val database = config.getInt("redis.database", DEFAULT_DATABASE)
+    val useSsl = config.getBoolean("redis.ssl", false)
+    val timeoutSeconds =
+      config.getLong("redis.timeout-seconds", DEFAULT_TIMEOUT_SECONDS).coerceAtLeast(1L)
+    val password = config.getString("redis.password", "")
+
+    val uri =
+      RedisURI.builder()
+        .withHost(host)
+        .withPort(port)
+        .withDatabase(database)
+        .withSsl(useSsl)
+        .withTimeout(Duration.ofSeconds(timeoutSeconds))
+        .apply { if (password.isNotEmpty()) withPassword(password.toCharArray()) }
+        .build()
+
+    runCatching {
+        val redisClient = RedisClient.create(uri)
+        redisClient.setOptions(
+          ClientOptions.builder()
+            .socketOptions(
+              SocketOptions.builder().connectTimeout(Duration.ofSeconds(timeoutSeconds)).build()
+            )
+            .build()
+        )
+        client = redisClient
+        connection = redisClient.connect()
+        pubSubConnection = redisClient.connectPubSub()
+      }
+      .onSuccess {
+        isAvailable = true
+        logger.info("[Redis] Connected to $host:$port (database $database).")
+      }
+      .onFailure { error ->
+        logger.log(
+          Level.WARNING,
+          "[Redis] Could not connect to $host:$port; cross-server features are disabled.",
+          error,
+        )
+        shutdown()
+      }
+  }
+
+  /** Publishes [message] to [channel] without blocking the caller. No-op when unavailable. */
+  fun publishAsync(channel: String, message: String) {
+    val activeConnection = connection
+    if (!isAvailable || activeConnection == null) return
+    runCatching {
+        activeConnection.async().publish(channel, message).exceptionally { error ->
+          logger.log(Level.FINE, "[Redis] Publish to $channel failed.", error)
+          0L
+        }
+      }
+      .onFailure { error -> logger.log(Level.FINE, "[Redis] Publish to $channel failed.", error) }
+  }
+
+  /** Subscribes to [channel] and forwards each received message body to [onMessage]. */
+  fun subscribe(channel: String, onMessage: (String) -> Unit) {
+    val pubSub = pubSubConnection ?: return
+    pubSub.addListener(
+      object : RedisPubSubAdapter<String, String>() {
+        override fun message(receivedChannel: String, message: String) {
+          if (receivedChannel == channel) onMessage(message)
+        }
+      }
+    )
+    pubSub.sync().subscribe(channel)
+  }
+
+  fun shutdown() {
+    isAvailable = false
+    runCatching { connection?.close() }
+    runCatching { pubSubConnection?.close() }
+    runCatching { client?.shutdown(Duration.ZERO, SHUTDOWN_TIMEOUT) }
+    connection = null
+    pubSubConnection = null
+    client = null
+  }
+
+  private companion object {
+    const val DEFAULT_HOST = "localhost"
+    const val DEFAULT_PORT = 6379
+    const val DEFAULT_DATABASE = 0
+    const val DEFAULT_TIMEOUT_SECONDS = 10L
+    val SHUTDOWN_TIMEOUT: Duration = Duration.ofSeconds(2)
+  }
+}

--- a/src/main/kotlin/space/kaelus/sloth/redis/RedisManager.kt
+++ b/src/main/kotlin/space/kaelus/sloth/redis/RedisManager.kt
@@ -18,8 +18,11 @@
 package space.kaelus.sloth.redis
 
 import io.lettuce.core.ClientOptions
+import io.lettuce.core.KeyScanCursor
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisURI
+import io.lettuce.core.ScanArgs
+import io.lettuce.core.SetArgs
 import io.lettuce.core.SocketOptions
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.pubsub.RedisPubSubAdapter
@@ -108,6 +111,50 @@ class RedisManager(private val configManager: ConfigManager, private val logger:
       .onFailure { error -> logger.log(Level.FINE, "[Redis] Publish to $channel failed.", error) }
   }
 
+  /** Stores [value] under [key] with a [ttlSeconds] expiry, without blocking the caller. */
+  fun setWithTtl(key: String, value: String, ttlSeconds: Long) {
+    val activeConnection = connection
+    if (!isAvailable || activeConnection == null) return
+    runCatching {
+        activeConnection.async().set(key, value, SetArgs.Builder.ex(ttlSeconds)).exceptionally {
+          error ->
+          logger.log(Level.FINE, "[Redis] Set $key failed.", error)
+          null
+        }
+      }
+      .onFailure { error -> logger.log(Level.FINE, "[Redis] Set $key failed.", error) }
+  }
+
+  /**
+   * Returns the values of every key matching [pattern]. Blocking (SCAN + MGET) — call off the main
+   * thread. Returns an empty list when unavailable or on error.
+   */
+  @Suppress("SpreadOperator") // Lettuce mget only accepts varargs; the key list is small.
+  fun scanValues(pattern: String): List<String> {
+    val activeConnection = connection
+    if (!isAvailable || activeConnection == null) return emptyList()
+    return runCatching {
+        val commands = activeConnection.sync()
+        val args = ScanArgs.Builder.matches(pattern).limit(SCAN_BATCH)
+        val keys = ArrayList<String>()
+        var cursor: KeyScanCursor<String> = commands.scan(args)
+        keys.addAll(cursor.keys)
+        while (!cursor.isFinished) {
+          cursor = commands.scan(cursor, args)
+          keys.addAll(cursor.keys)
+        }
+        if (keys.isEmpty()) {
+          emptyList()
+        } else {
+          commands.mget(*keys.toTypedArray()).mapNotNull { if (it.hasValue()) it.value else null }
+        }
+      }
+      .getOrElse { error ->
+        logger.log(Level.FINE, "[Redis] Scan $pattern failed.", error)
+        emptyList()
+      }
+  }
+
   /** Subscribes to [channel] and forwards each received message body to [onMessage]. */
   fun subscribe(channel: String, onMessage: (String) -> Unit) {
     val pubSub = pubSubConnection ?: return
@@ -136,6 +183,7 @@ class RedisManager(private val configManager: ConfigManager, private val logger:
     const val DEFAULT_PORT = 6379
     const val DEFAULT_DATABASE = 0
     const val DEFAULT_TIMEOUT_SECONDS = 10L
+    const val SCAN_BATCH = 256L
     val SHUTDOWN_TIMEOUT: Duration = Duration.ofSeconds(2)
   }
 }

--- a/src/main/kotlin/space/kaelus/sloth/redis/SuspiciousSnapshot.kt
+++ b/src/main/kotlin/space/kaelus/sloth/redis/SuspiciousSnapshot.kt
@@ -1,0 +1,41 @@
+/*
+ * This file is part of SlothAC - https://github.com/KaelusMC/SlothAC
+ * Copyright (C) 2026 KaelusMC
+ *
+ * SlothAC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SlothAC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package space.kaelus.sloth.redis
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * One suspicious player, as shared across servers for the network-wide `/sloth suspicious` list.
+ * Stored in Redis under a per-player key with a TTL, so stale entries expire on their own.
+ *
+ * @property server display name of the server the player is on
+ * @property uuid the player's UUID
+ * @property name the player's name
+ * @property buffer the player's current AI suspicion buffer
+ * @property ping the player's ping in milliseconds
+ */
+data class SuspiciousSnapshot
+@JsonCreator
+constructor(
+  @param:JsonProperty("server") val server: String,
+  @param:JsonProperty("uuid") val uuid: String,
+  @param:JsonProperty("name") val name: String,
+  @param:JsonProperty("buffer") val buffer: Double,
+  @param:JsonProperty("ping") val ping: Int,
+)

--- a/src/main/kotlin/space/kaelus/sloth/redis/SuspiciousSnapshot.kt
+++ b/src/main/kotlin/space/kaelus/sloth/redis/SuspiciousSnapshot.kt
@@ -29,6 +29,8 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @property name the player's name
  * @property buffer the player's current AI suspicion buffer
  * @property ping the player's ping in milliseconds
+ * @property updatedAt epoch millis when this snapshot was published, used to de-duplicate a player
+ *   who still has a stale entry from a server they just left (keep the freshest)
  */
 data class SuspiciousSnapshot
 @JsonCreator
@@ -38,4 +40,5 @@ constructor(
   @param:JsonProperty("name") val name: String,
   @param:JsonProperty("buffer") val buffer: Double,
   @param:JsonProperty("ping") val ping: Int,
+  @param:JsonProperty("updatedAt") val updatedAt: Long,
 )

--- a/src/main/kotlin/space/kaelus/sloth/utils/Message.kt
+++ b/src/main/kotlin/space/kaelus/sloth/utils/Message.kt
@@ -133,6 +133,7 @@ enum class Message(val path: String) {
 
   // Cross-server
   CROSS_SERVER_ALERT_PREFIX("cross-server.alert-prefix"),
+  CROSS_SERVER_SERVER_TAG("cross-server.server-tag"),
 
   // Stats
   STATS_INVALID_PERIOD("stats.invalid-period"),

--- a/src/main/kotlin/space/kaelus/sloth/utils/Message.kt
+++ b/src/main/kotlin/space/kaelus/sloth/utils/Message.kt
@@ -131,6 +131,9 @@ enum class Message(val path: String) {
   SUSPICIOUS_TOP_PLAYER("suspicious.top-player"),
   SUSPICIOUS_TOP_PLAYER_HOVER("suspicious.top-player-hover"),
 
+  // Cross-server
+  CROSS_SERVER_ALERT_PREFIX("cross-server.alert-prefix"),
+
   // Stats
   STATS_INVALID_PERIOD("stats.invalid-period"),
   STATS_HEADER("stats.header"),

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,7 +2,7 @@
 # Copyright 2026 KaelusMC, DefineOutside and contributors, Licensed under GPLv3.
 
 # Do not change this value manually.
-config-version: 2
+config-version: 3
 
 # Locale: en, ru
 locale: "en"
@@ -161,6 +161,15 @@ cross-server:
     regular: true
     # Suspicious-buffer alerts.
     suspicious: true
+  # Share the live suspicious-players list (/sloth suspicious list|top) across servers.
+  # Requires cross-server.enabled. Nothing is written to Redis unless this is on; entries
+  # carry a TTL, so offline servers and players that calm down drop off automatically.
+  suspicious-sync:
+    enabled: true
+    # How long an entry survives in Redis without a refresh, in seconds.
+    ttl-seconds: 30
+    # How often this server republishes its suspicious players, in seconds.
+    refresh-seconds: 10
 
 suspicious:
   alerts:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -159,13 +159,12 @@ cross-server:
   alerts:
     # Violation flags (rule breakers).
     regular: true
-    # Suspicious-buffer alerts.
+    # Suspicious-buffer alerts. When on, this also shares the live suspicious-players list
+    # (/sloth suspicious list|top) across servers. Nothing is written to Redis unless this is on;
+    # list entries carry a TTL, so offline servers and players that calm down drop off by themselves.
     suspicious: true
-  # Share the live suspicious-players list (/sloth suspicious list|top) across servers.
-  # Requires cross-server.enabled. Nothing is written to Redis unless this is on; entries
-  # carry a TTL, so offline servers and players that calm down drop off automatically.
+  # Tuning for the shared suspicious-players list (only used when cross-server.alerts.suspicious is on).
   suspicious-sync:
-    enabled: true
     # How long an entry survives in Redis without a refresh, in seconds.
     ttl-seconds: 30
     # How often this server republishes its suspicious players, in seconds.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -2,7 +2,7 @@
 # Copyright 2026 KaelusMC, DefineOutside and contributors, Licensed under GPLv3.
 
 # Do not change this value manually.
-config-version: 1
+config-version: 2
 
 # Locale: en, ru
 locale: "en"
@@ -130,6 +130,37 @@ database:
     username: "root"
     password: "password"
     use-ssl: false
+
+# Redis connection, used by cross-server alerting.
+redis:
+  # Enable the Redis connection. Required for cross-server alerts below.
+  enabled: false
+  host: "localhost"
+  port: 6379
+  # Leave empty if your Redis instance has no password.
+  password: ""
+  # Logical database index.
+  database: 0
+  # Connect over TLS (rediss://).
+  ssl: false
+  # Connection and command timeout, in seconds.
+  timeout-seconds: 10
+
+# Mirror alerts between servers that share the same Redis.
+cross-server:
+  # Show alerts from other servers, and send this server's alerts to them.
+  # Requires redis.enabled above.
+  enabled: false
+  # Name shown as the origin tag for alerts coming from this server, e.g. [Lobby].
+  server-name: "server-1"
+  # Redis pub/sub channel. Every server in the network must use the same value.
+  channel: "slothac:alerts"
+  # Which alert types to mirror across servers.
+  alerts:
+    # Violation flags (rule breakers).
+    regular: true
+    # Suspicious-buffer alerts.
+    suspicious: true
 
 suspicious:
   alerts:

--- a/src/main/resources/messages/messages_en.yml
+++ b/src/main/resources/messages/messages_en.yml
@@ -127,6 +127,8 @@ suspicious:
 cross-server:
   # Origin tag prepended to alerts mirrored from other servers. <server> is the source server name.
   alert-prefix: "<dark_gray>[</dark_gray><color:#74ebd5><server></color><dark_gray>]</dark_gray>"
+  # Server tag prepended to entries in the network-wide /sloth suspicious list and top.
+  server-tag: "<dark_gray>[</dark_gray><color:#74ebd5><server></color><dark_gray>]</dark_gray>"
 
 stats:
   invalid-period: "<prefix> <color:#ff4b2b>Invalid period. Use: <options>.</color>"

--- a/src/main/resources/messages/messages_en.yml
+++ b/src/main/resources/messages/messages_en.yml
@@ -124,6 +124,10 @@ suspicious:
   top-player: "<prefix> <color:#00b4db>Most Suspicious:</color> <white><player></white> <gray>with buffer</gray> <color:#ff4b2b><buffer></color>"
   top-player-hover: "<gray>Enable monitor</gray>"
 
+cross-server:
+  # Origin tag prepended to alerts mirrored from other servers. <server> is the source server name.
+  alert-prefix: "<dark_gray>[</dark_gray><color:#74ebd5><server></color><dark_gray>]</dark_gray>"
+
 stats:
   invalid-period: "<prefix> <color:#ff4b2b>Invalid period. Use: <options>.</color>"
   header: "<gradient:#8e9eab:#eef2f3>---- [ Sloth Stats ] ----</gradient>"

--- a/src/main/resources/messages/messages_ru.yml
+++ b/src/main/resources/messages/messages_ru.yml
@@ -127,6 +127,8 @@ suspicious:
 cross-server:
   # Префикс источника для алёртов с других серверов. <server> — имя сервера-источника.
   alert-prefix: "<dark_gray>[</dark_gray><color:#74ebd5><server></color><dark_gray>]</dark_gray>"
+  # Тег сервера для строк в общесетевом /sloth suspicious list и top.
+  server-tag: "<dark_gray>[</dark_gray><color:#74ebd5><server></color><dark_gray>]</dark_gray>"
 
 stats:
   invalid-period: "<prefix> <color:#ff4b2b>Неверный период. Используй: <options>.</color>"

--- a/src/main/resources/messages/messages_ru.yml
+++ b/src/main/resources/messages/messages_ru.yml
@@ -124,6 +124,10 @@ suspicious:
   top-player: "<prefix> <color:#00b4db>Самый подозрительный:</color> <white><player></white> <gray>с буфером</gray> <color:#ff4b2b><buffer></color>"
   top-player-hover: "<gray>Включить мониторинг</gray>"
 
+cross-server:
+  # Префикс источника для алёртов с других серверов. <server> — имя сервера-источника.
+  alert-prefix: "<dark_gray>[</dark_gray><color:#74ebd5><server></color><dark_gray>]</dark_gray>"
+
 stats:
   invalid-period: "<prefix> <color:#ff4b2b>Неверный период. Используй: <options>.</color>"
   header: "<gradient:#8e9eab:#eef2f3>---- [ Статистика Sloth ] ----</gradient>"

--- a/src/test/kotlin/space/kaelus/sloth/command/commands/admin/SuspiciousDedupeTest.kt
+++ b/src/test/kotlin/space/kaelus/sloth/command/commands/admin/SuspiciousDedupeTest.kt
@@ -1,0 +1,56 @@
+/*
+ * This file is part of SlothAC - https://github.com/KaelusMC/SlothAC
+ * Copyright (C) 2026 KaelusMC
+ *
+ * SlothAC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SlothAC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package space.kaelus.sloth.command.commands.admin
+
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+class SuspiciousDedupeTest {
+
+  @Test
+  fun `a player on two servers collapses to the freshest entry`() {
+    val uuid = "11111111-1111-1111-1111-111111111111"
+    val stale = DisplayEntry("lite1", uuid, "season", 9.4, 38, 1_000L)
+    val fresh = DisplayEntry("lite2", uuid, "season", 9.4, 43, 2_000L)
+
+    val result = dedupeByPlayer(listOf(stale, fresh))
+
+    assertEquals(1, result.size)
+    assertEquals("lite2", result.single().server, "should keep the server with the newest update")
+  }
+
+  @Test
+  fun `local entry wins over a stale remote one for the same player`() {
+    val uuid = "22222222-2222-2222-2222-222222222222"
+    val remote = DisplayEntry("lite1", uuid, "season", 9.4, 38, 9_999L)
+    val local = DisplayEntry("lite2", uuid, "season", 9.4, 43, Long.MAX_VALUE)
+
+    val result = dedupeByPlayer(listOf(remote, local))
+
+    assertEquals(1, result.size)
+    assertEquals("lite2", result.single().server)
+  }
+
+  @Test
+  fun `different players are all kept`() {
+    val a = DisplayEntry("lite1", "a", "alice", 5.0, 10, 1L)
+    val b = DisplayEntry("lite2", "b", "bob", 7.0, 20, 1L)
+
+    assertEquals(2, dedupeByPlayer(listOf(a, b)).size)
+  }
+}

--- a/src/test/kotlin/space/kaelus/sloth/config/ConfigMigrationsTest.kt
+++ b/src/test/kotlin/space/kaelus/sloth/config/ConfigMigrationsTest.kt
@@ -161,6 +161,10 @@ class ConfigMigrationsTest {
     val merged = userFile.readText()
     assertContains(merged, "continuous: false")
     assertContains(merged, "config-version: ${ConfigMigrations.LATEST_VERSION}")
+    // v2 added the redis and cross-server sections; they must be merged in.
+    assertContains(merged, "# Redis connection, used by cross-server alerting.")
+    assertContains(merged, """server-name: "server-1"""")
+    assertContains(merged, """channel: "slothac:alerts"""")
     assertContains(merged, """server: "https://example.internal/inference"""")
     assertContains(merged, """api-key: "MY_KEY"""")
     assertContains(merged, """locale: "ru"""")

--- a/src/test/kotlin/space/kaelus/sloth/config/ConfigMigrationsTest.kt
+++ b/src/test/kotlin/space/kaelus/sloth/config/ConfigMigrationsTest.kt
@@ -165,6 +165,9 @@ class ConfigMigrationsTest {
     assertContains(merged, "# Redis connection, used by cross-server alerting.")
     assertContains(merged, """server-name: "server-1"""")
     assertContains(merged, """channel: "slothac:alerts"""")
+    // v3 added the suspicious-sync block under cross-server.
+    assertContains(merged, "suspicious-sync:")
+    assertContains(merged, "ttl-seconds: 30")
     assertContains(merged, """server: "https://example.internal/inference"""")
     assertContains(merged, """api-key: "MY_KEY"""")
     assertContains(merged, """locale: "ru"""")

--- a/src/test/kotlin/space/kaelus/sloth/redis/CrossServerAlertServiceTest.kt
+++ b/src/test/kotlin/space/kaelus/sloth/redis/CrossServerAlertServiceTest.kt
@@ -1,0 +1,198 @@
+/*
+ * This file is part of SlothAC - https://github.com/KaelusMC/SlothAC
+ * Copyright (C) 2026 KaelusMC
+ *
+ * SlothAC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SlothAC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package space.kaelus.sloth.redis
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import java.util.logging.Logger
+import net.kyori.adventure.platform.bukkit.BukkitAudiences
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.spongepowered.configurate.yaml.YamlConfigurationLoader
+import space.kaelus.sloth.alert.AlertManager
+import space.kaelus.sloth.alert.AlertType
+import space.kaelus.sloth.config.ConfigManager
+import space.kaelus.sloth.config.ConfigView
+import space.kaelus.sloth.config.LocaleManager
+import space.kaelus.sloth.utils.MessageUtil
+
+class CrossServerAlertServiceTest {
+  private val gson = GsonComponentSerializer.gson()
+  private val mapper = ObjectMapper()
+
+  @BeforeEach
+  fun setUp() {
+    // Initialise the real MessageUtil so the receive path can render the [server] prefix.
+    val localeManager = mockk<LocaleManager>(relaxed = true)
+    every { localeManager.getRawMessage(any()) } returns "[<server>]"
+    MessageUtil.init(
+      localeManager,
+      mockk<BukkitAudiences>(relaxed = true),
+      Logger.getLogger("test"),
+    )
+  }
+
+  @Test
+  fun `publishes only the enabled alert types`() {
+    val redis = mockk<RedisManager>(relaxed = true)
+    every { redis.isAvailable } returns true
+    val alerts = mockk<AlertManager>(relaxed = true)
+    val service =
+      service(
+        """
+        cross-server:
+          enabled: true
+          server-name: "Lobby"
+          channel: "test:alerts"
+          alerts:
+            regular: true
+            suspicious: false
+        """
+          .trimIndent(),
+        redis,
+        alerts,
+      )
+
+    service.start()
+    service.publish(AlertType.REGULAR, Component.text("a"))
+    service.publish(AlertType.SUSPICIOUS, Component.text("b"))
+    service.publish(AlertType.BRAND, Component.text("c"))
+
+    verify(exactly = 1) { redis.publishAsync("test:alerts", any()) }
+    verify(exactly = 1) { alerts.crossServerPublisher = any() }
+    verify(exactly = 1) { redis.subscribe("test:alerts", any()) }
+  }
+
+  @Test
+  fun `does nothing when cross-server is disabled`() {
+    val redis = mockk<RedisManager>(relaxed = true)
+    val alerts = mockk<AlertManager>(relaxed = true)
+    val service = service("cross-server:\n  enabled: false\n", redis, alerts)
+
+    service.start()
+    service.publish(AlertType.REGULAR, Component.text("a"))
+
+    verify(exactly = 0) { redis.start() }
+    verify(exactly = 0) { redis.subscribe(any(), any()) }
+    verify(exactly = 0) { redis.publishAsync(any(), any()) }
+    verify(exactly = 0) { alerts.crossServerPublisher = any() }
+  }
+
+  @Test
+  fun `stays local when redis is unavailable`() {
+    val redis = mockk<RedisManager>(relaxed = true)
+    every { redis.isAvailable } returns false
+    val alerts = mockk<AlertManager>(relaxed = true)
+    val service = service("cross-server:\n  enabled: true\n", redis, alerts)
+
+    service.start()
+    service.publish(AlertType.REGULAR, Component.text("a"))
+
+    verify(exactly = 1) { redis.start() }
+    verify(exactly = 0) { redis.subscribe(any(), any()) }
+    verify(exactly = 0) { redis.publishAsync(any(), any()) }
+    verify(exactly = 0) { alerts.crossServerPublisher = any() }
+  }
+
+  @Test
+  fun `delivers foreign alerts and ignores its own`() {
+    val redis = mockk<RedisManager>(relaxed = true)
+    every { redis.isAvailable } returns true
+    val incoming = slot<(String) -> Unit>()
+    every { redis.subscribe(any(), capture(incoming)) } just runs
+    val published = slot<String>()
+    every { redis.publishAsync(any(), capture(published)) } just runs
+    val alerts = mockk<AlertManager>(relaxed = true)
+    val service =
+      service(
+        """
+        cross-server:
+          enabled: true
+          server-name: "Lobby"
+          channel: "test:alerts"
+          alerts:
+            regular: true
+            suspicious: true
+        """
+          .trimIndent(),
+        redis,
+        alerts,
+      )
+    service.start()
+
+    // A message this server published must be ignored when it loops back.
+    service.publish(AlertType.REGULAR, Component.text("local"))
+    incoming.captured.invoke(published.captured)
+    verify(exactly = 0) { alerts.deliver(any(), any()) }
+
+    // A message from another server is delivered locally.
+    val foreign =
+      mapper.writeValueAsString(
+        CrossServerAlert("other-origin", "PvP", "REGULAR", gson.serialize(Component.text("remote")))
+      )
+    incoming.captured.invoke(foreign)
+    verify(exactly = 1) { alerts.deliver(any(), AlertType.REGULAR) }
+  }
+
+  @Test
+  fun `ignores malformed and unknown-type messages`() {
+    val redis = mockk<RedisManager>(relaxed = true)
+    every { redis.isAvailable } returns true
+    val incoming = slot<(String) -> Unit>()
+    every { redis.subscribe(any(), capture(incoming)) } just runs
+    val alerts = mockk<AlertManager>(relaxed = true)
+    val service = service("cross-server:\n  enabled: true\n", redis, alerts)
+    service.start()
+
+    incoming.captured.invoke("not even json")
+    incoming.captured.invoke(
+      mapper.writeValueAsString(
+        CrossServerAlert("o", "PvP", "NONSENSE", gson.serialize(Component.text("x")))
+      )
+    )
+
+    verify(exactly = 0) { alerts.deliver(any(), any()) }
+  }
+
+  private fun service(
+    yaml: String,
+    redis: RedisManager,
+    alerts: AlertManager,
+  ): CrossServerAlertService {
+    val configManager = mockk<ConfigManager>()
+    every { configManager.config } returns configView(yaml)
+    return CrossServerAlertService(
+      configManager,
+      redis,
+      alerts,
+      Logger.getLogger("cross-server-test"),
+    )
+  }
+
+  private fun configView(yaml: String): ConfigView {
+    val loader = YamlConfigurationLoader.builder().source { yaml.reader().buffered() }.build()
+    return ConfigView(loader.load())
+  }
+}

--- a/src/test/kotlin/space/kaelus/sloth/redis/CrossServerAlertTest.kt
+++ b/src/test/kotlin/space/kaelus/sloth/redis/CrossServerAlertTest.kt
@@ -1,0 +1,51 @@
+/*
+ * This file is part of SlothAC - https://github.com/KaelusMC/SlothAC
+ * Copyright (C) 2026 KaelusMC
+ *
+ * SlothAC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SlothAC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package space.kaelus.sloth.redis
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import kotlin.test.assertEquals
+import net.kyori.adventure.text.minimessage.MiniMessage
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
+import org.junit.jupiter.api.Test
+
+class CrossServerAlertTest {
+  private val mapper = ObjectMapper()
+  private val gson = GsonComponentSerializer.gson()
+
+  @Test
+  fun `payload round-trips through jackson`() {
+    val original = CrossServerAlert("origin-1", "Lobby", "REGULAR", """{"text":"hi"}""")
+
+    val json = mapper.writeValueAsString(original)
+    val restored = mapper.readValue(json, CrossServerAlert::class.java)
+
+    assertEquals(original, restored)
+  }
+
+  @Test
+  fun `component survives the gson round-trip inside the payload`() {
+    val component = MiniMessage.miniMessage().deserialize("<red>Player</red> <gray>flagged</gray>")
+    val payload = CrossServerAlert("o", "Lobby", "SUSPICIOUS", gson.serialize(component))
+
+    val json = mapper.writeValueAsString(payload)
+    val restored = mapper.readValue(json, CrossServerAlert::class.java)
+    val restoredComponent = gson.deserialize(restored.component)
+
+    assertEquals(gson.serialize(component), gson.serialize(restoredComponent))
+  }
+}

--- a/src/test/kotlin/space/kaelus/sloth/redis/CrossServerSuspiciousServiceTest.kt
+++ b/src/test/kotlin/space/kaelus/sloth/redis/CrossServerSuspiciousServiceTest.kt
@@ -1,0 +1,164 @@
+/*
+ * This file is part of SlothAC - https://github.com/KaelusMC/SlothAC
+ * Copyright (C) 2026 KaelusMC
+ *
+ * SlothAC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SlothAC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package space.kaelus.sloth.redis
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import java.util.UUID
+import java.util.logging.Logger
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.bukkit.entity.Player
+import org.junit.jupiter.api.Test
+import org.spongepowered.configurate.yaml.YamlConfigurationLoader
+import space.kaelus.sloth.checks.CheckManager
+import space.kaelus.sloth.checks.impl.ai.AiCheck
+import space.kaelus.sloth.config.ConfigManager
+import space.kaelus.sloth.config.ConfigView
+import space.kaelus.sloth.player.PlayerDataManager
+import space.kaelus.sloth.player.SlothPlayer
+import space.kaelus.sloth.scheduler.SchedulerService
+
+class CrossServerSuspiciousServiceTest {
+  private val mapper = ObjectMapper()
+
+  private val enabledYaml =
+    """
+    cross-server:
+      enabled: true
+      server-name: "Lobby"
+      channel: "test:alerts"
+      suspicious-sync:
+        enabled: true
+        ttl-seconds: 30
+        refresh-seconds: 10
+    """
+      .trimIndent()
+
+  @Test
+  fun `payload round-trips through jackson`() {
+    val original = SuspiciousSnapshot("Lobby", UUID.randomUUID().toString(), "Notch", 27.5, 42)
+
+    val restored =
+      mapper.readValue(mapper.writeValueAsString(original), SuspiciousSnapshot::class.java)
+
+    assertEquals(original, restored)
+  }
+
+  @Test
+  fun `publishes only suspicious players to redis when enabled`() {
+    val redis = mockk<RedisManager>(relaxed = true)
+    every { redis.isAvailable } returns true
+    val scheduler = mockk<SchedulerService>(relaxed = true)
+    val refresh = slot<Runnable>()
+    every { scheduler.runTimer(capture(refresh), any(), any()) } returns mockk(relaxed = true)
+    val suspect = UUID.randomUUID()
+    val playerData = mockk<PlayerDataManager>()
+    every { playerData.getPlayers() } returns
+      listOf(player(suspect, "Cheater", 30.0, 50), player(UUID.randomUUID(), "Calm", 0.0, 40))
+    val keys = mutableListOf<String>()
+    every { redis.setWithTtl(capture(keys), any(), any()) } just runs
+
+    val service = service(enabledYaml, redis, scheduler, playerData)
+    service.start()
+    refresh.captured.run() // one refresh cycle
+
+    assertTrue(service.isActive)
+    assertEquals(1, keys.size, "only the player with buffer > 0 should be published")
+    assertTrue(keys.single().endsWith(":Lobby:$suspect"))
+  }
+
+  @Test
+  fun `does not touch redis when suspicious-sync is disabled`() {
+    val redis = mockk<RedisManager>(relaxed = true)
+    val scheduler = mockk<SchedulerService>(relaxed = true)
+    val service =
+      service(
+        "cross-server:\n  enabled: true\n  suspicious-sync:\n    enabled: false\n",
+        redis,
+        scheduler,
+        mockk(relaxed = true),
+      )
+
+    service.start()
+
+    assertFalse(service.isActive)
+    verify(exactly = 0) { redis.start() }
+    verify(exactly = 0) { scheduler.runTimer(any(), any(), any()) }
+    verify(exactly = 0) { redis.setWithTtl(any(), any(), any()) }
+  }
+
+  @Test
+  fun `fetchRemote returns other servers and ignores own and malformed entries`() {
+    val redis = mockk<RedisManager>(relaxed = true)
+    every { redis.isAvailable } returns true
+    every { redis.scanValues(any()) } returns
+      listOf(
+        mapper.writeValueAsString(SuspiciousSnapshot("Lobby", "u1", "Self", 10.0, 5)),
+        mapper.writeValueAsString(SuspiciousSnapshot("PvP", "u2", "Remote", 22.0, 7)),
+        "not json",
+      )
+    val service = service(enabledYaml, redis, mockk(relaxed = true), mockk(relaxed = true))
+    service.start()
+
+    val remote = service.fetchRemote()
+
+    assertEquals(1, remote.size)
+    assertEquals("PvP", remote.single().server)
+    assertEquals("Remote", remote.single().name)
+  }
+
+  private fun player(uuid: UUID, name: String, buffer: Double, ping: Int): SlothPlayer {
+    val check = mockk<AiCheck>()
+    every { check.buffer } returns buffer
+    val bukkitPlayer = mockk<Player>()
+    every { bukkitPlayer.name } returns name
+    every { bukkitPlayer.ping } returns ping
+    val checkManager = mockk<CheckManager>()
+    every { checkManager.getCheck(AiCheck::class.java) } returns check
+    val slothPlayer = mockk<SlothPlayer>()
+    every { slothPlayer.checkManager } returns checkManager
+    every { slothPlayer.uuid } returns uuid
+    every { slothPlayer.player } returns bukkitPlayer
+    return slothPlayer
+  }
+
+  private fun service(
+    yaml: String,
+    redis: RedisManager,
+    scheduler: SchedulerService,
+    playerData: PlayerDataManager,
+  ): CrossServerSuspiciousService {
+    val configManager = mockk<ConfigManager>()
+    val loader = YamlConfigurationLoader.builder().source { yaml.reader().buffered() }.build()
+    every { configManager.config } returns ConfigView(loader.load())
+    return CrossServerSuspiciousService(
+      configManager,
+      redis,
+      playerData,
+      scheduler,
+      Logger.getLogger("suspicious-test"),
+    )
+  }
+}

--- a/src/test/kotlin/space/kaelus/sloth/redis/CrossServerSuspiciousServiceTest.kt
+++ b/src/test/kotlin/space/kaelus/sloth/redis/CrossServerSuspiciousServiceTest.kt
@@ -59,7 +59,7 @@ class CrossServerSuspiciousServiceTest {
 
   @Test
   fun `payload round-trips through jackson`() {
-    val original = SuspiciousSnapshot("Lobby", UUID.randomUUID().toString(), "Notch", 27.5, 42)
+    val original = SuspiciousSnapshot("Lobby", UUID.randomUUID().toString(), "Notch", 27.5, 42, 1L)
 
     val restored =
       mapper.readValue(mapper.writeValueAsString(original), SuspiciousSnapshot::class.java)
@@ -116,8 +116,8 @@ class CrossServerSuspiciousServiceTest {
     every { redis.isAvailable } returns true
     every { redis.scanValues(any()) } returns
       listOf(
-        mapper.writeValueAsString(SuspiciousSnapshot("Lobby", "u1", "Self", 10.0, 5)),
-        mapper.writeValueAsString(SuspiciousSnapshot("PvP", "u2", "Remote", 22.0, 7)),
+        mapper.writeValueAsString(SuspiciousSnapshot("Lobby", "u1", "Self", 10.0, 5, 1L)),
+        mapper.writeValueAsString(SuspiciousSnapshot("PvP", "u2", "Remote", 22.0, 7, 2L)),
         "not json",
       )
     val service = service(enabledYaml, redis, mockk(relaxed = true), mockk(relaxed = true))

--- a/src/test/kotlin/space/kaelus/sloth/redis/CrossServerSuspiciousServiceTest.kt
+++ b/src/test/kotlin/space/kaelus/sloth/redis/CrossServerSuspiciousServiceTest.kt
@@ -49,8 +49,9 @@ class CrossServerSuspiciousServiceTest {
       enabled: true
       server-name: "Lobby"
       channel: "test:alerts"
+      alerts:
+        suspicious: true
       suspicious-sync:
-        enabled: true
         ttl-seconds: 30
         refresh-seconds: 10
     """
@@ -95,7 +96,7 @@ class CrossServerSuspiciousServiceTest {
     val scheduler = mockk<SchedulerService>(relaxed = true)
     val service =
       service(
-        "cross-server:\n  enabled: true\n  suspicious-sync:\n    enabled: false\n",
+        "cross-server:\n  enabled: true\n  alerts:\n    suspicious: false\n",
         redis,
         scheduler,
         mockk(relaxed = true),

--- a/src/test/kotlin/space/kaelus/sloth/redis/RedisCrossServerContainerTest.kt
+++ b/src/test/kotlin/space/kaelus/sloth/redis/RedisCrossServerContainerTest.kt
@@ -1,0 +1,87 @@
+/*
+ * This file is part of SlothAC - https://github.com/KaelusMC/SlothAC
+ * Copyright (C) 2026 KaelusMC
+ *
+ * SlothAC is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SlothAC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package space.kaelus.sloth.redis
+
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.logging.Logger
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.spongepowered.configurate.yaml.YamlConfigurationLoader
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+import space.kaelus.sloth.config.ConfigManager
+import space.kaelus.sloth.config.ConfigView
+
+@Tag("container")
+@Testcontainers(disabledWithoutDocker = true)
+class RedisCrossServerContainerTest {
+
+  @Test
+  fun `a message published on one manager is received by another over redis`() {
+    GenericContainer(DockerImageName.parse(REDIS_IMAGE)).withExposedPorts(REDIS_PORT).use {
+      container ->
+      container.start()
+      val publisher = manager(container)
+      val subscriber = manager(container)
+      try {
+        publisher.start()
+        subscriber.start()
+        assertTrue(publisher.isAvailable)
+        assertTrue(subscriber.isAvailable)
+
+        val received = LinkedBlockingQueue<String>()
+        subscriber.subscribe(CHANNEL) { message -> received.add(message) }
+        publisher.publishAsync(CHANNEL, PAYLOAD)
+
+        assertEquals(PAYLOAD, received.poll(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+      } finally {
+        publisher.shutdown()
+        subscriber.shutdown()
+      }
+    }
+  }
+
+  private fun manager(container: GenericContainer<*>): RedisManager {
+    val yaml =
+      """
+      redis:
+        enabled: true
+        host: "${container.host}"
+        port: ${container.firstMappedPort}
+      """
+        .trimIndent()
+    val loader = YamlConfigurationLoader.builder().source { yaml.reader().buffered() }.build()
+    val configManager = mockk<ConfigManager>()
+    every { configManager.config } returns ConfigView(loader.load())
+    return RedisManager(configManager, Logger.getLogger("redis-it"))
+  }
+
+  private companion object {
+    const val REDIS_IMAGE = "redis:7-alpine"
+    const val REDIS_PORT = 6379
+    const val CHANNEL = "slothac:it-alerts"
+    const val PAYLOAD = "cross-server-payload"
+    const val AWAIT_TIMEOUT_SECONDS = 5L
+  }
+}


### PR DESCRIPTION
## Summary

Adds opt-in **cross-server alerting and a network-wide suspicious-players list** over Redis
(using the Lettuce client). When enabled, violation (`REGULAR`) and `SUSPICIOUS` alerts raised on
one server are mirrored to subscribed staff on every other server sharing the same Redis, and
`/sloth suspicious list|top` show a network-wide view. Everything is off by default and degrades
gracefully — if Redis is disabled or unreachable, the plugin keeps working exactly as before.

## What's added

- **Cross-server alert mirroring** (`REGULAR` + `SUSPICIOUS`, each toggleable) via Redis pub/sub.
  The origin server publishes the rendered alert; receivers prepend an `[server]` origin tag and
  deliver it through the existing alert subscription (permissions + console toggles still apply).
  A per-process origin id drops a server's own messages (loop prevention).
- **Network-wide suspicious list.** While `cross-server.alerts.suspicious` is on, each server
  republishes its suspicious players (`AiCheck` buffer > 0) to per-player Redis keys with a TTL, so
  `/sloth suspicious list|top` merge the live local view with the other servers' entries (tagged
  with `[server]`). Keys expire on their own — nothing accumulates in Redis (pub/sub + TTL keys, no
  Streams/Lists). When the switch is off, **nothing is written to Redis** and the commands stay
  local, unchanged.

## Configuration (`config-version` 1 → 3, auto-merged by the existing updater)

```yaml
redis:
  enabled: false
  host: "localhost"
  port: 6379
  password: ""
  database: 0
  ssl: false
  timeout-seconds: 10

cross-server:
  enabled: false            # requires redis.enabled
  server-name: "server-1"   # origin tag shown to other servers, e.g. [Lobby]
  channel: "slothac:alerts"  # all servers in the network share this value
  alerts:
    regular: true           # mirror violation flags
    suspicious: true        # mirror suspicious alerts AND share the live suspicious list
  suspicious-sync:          # tuning for the shared list (used only when alerts.suspicious is on)
    ttl-seconds: 30
    refresh-seconds: 10
```

## Implementation notes

- New package `space.kaelus.sloth.redis`: `RedisManager` (resilient Lettuce connection, mirrors
  `DatabaseManager`'s degraded-mode pattern), `CrossServerAlertService`, `CrossServerSuspiciousService`,
  and the `CrossServerAlert` / `SuspiciousSnapshot` Jackson payloads.
- `AlertManager.send` is split into `deliver` (local subscribers + console) plus a settable
  `CrossServerPublisher` hook; existing callers are unchanged and the alert package keeps no
  dependency on the Redis transport.
- **Netty is intentionally neither relocated nor bundled.** PacketEvents locates the player's Netty
  `Channel` by reflecting on its `io.netty.channel.Channel` field type; relocating Netty breaks that
  lookup at join. Lettuce therefore shares the server's Netty (`exclude(group = "io.netty")` on the
  Lettuce dependency, `compileOnly`/`testRuntimeOnly` Netty). Lettuce, Reactor and reactive-streams
  are relocated under `space.kaelus.sloth.libs.*`.
- `SlothCore` starts/stops both services with the rest of the runtime; on reload it restarts Redis
  once and re-initialises both consumers so the alert subscription survives a `/sloth reload`.

## Testing

- Unit tests for payload round-trips, publish/receive filtering (own-origin and disabled-type drop),
  suspicious publish gating and remote fetch filtering, and the config migration to v3.
- A `@Tag("container")` Testcontainers Redis end-to-end test (excluded from the default `test` task).

## Notes / out of scope

- `/sloth suspicious flagged` stays local (it reads DB flag counts for locally-online players; a
  network-wide version needs a cross-server online roster).
- Mirrored alert messages render in the origin server's locale, and `/tp` / monitor click targets
  point at the local server — the `[server]` tag signals the real origin.
